### PR TITLE
feat: Geometry field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+2.2.0
+-----
+
+### Добавлено:
+- Новый тип поля `GeometryField` с поддержкой работы в форматах Well-Known Binary, Well-Known Text, GeoJSON и
+    Internal(MySQL internal geometry format);
+- Хэлпер `\WebArch\BitrixOrmTools\SqlExpression\MySQL\SqlExpression` и его специфическая часть
+    `\WebArch\BitrixOrmTools\SqlExpression\MySQL\Spatial` для работы со spatial функциями; 
+- Метод `PlaceholderTypeTrait::getPlaceholderAndValue()` для автоматического определения типа placeholder и его
+    значения по любому из поддерживаемых в `\Bitrix\Main\DB\SqlExpression::execPlaceholders()` типов данных.
+
 2.1.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "webarchitect609/bitrix-orm-tools",
   "description": "Bitrix orm table class tools.",
+  "version": "2.2.0",
   "type": "library",
   "license": "MIT",
   "authors": [

--- a/src/main/Enum/GeometryFormat.php
+++ b/src/main/Enum/GeometryFormat.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\Enum;
+
+use ReflectionClass;
+
+class GeometryFormat
+{
+    const INTERNAL = 'Internal';
+
+    const WKB = 'Well-Known Binary';
+
+    const WKT = 'Well-Known Text';
+
+    const GEO_JSON = 'GeoJSON';
+
+    /**
+     * Checks whether the $format is supported.
+     *
+     * @param string $format
+     *
+     * @return bool
+     */
+    public static function isSupported(string $format): bool
+    {
+        return in_array($format, self::getConstants());
+    }
+
+    /**
+     * Returns all supported formats.
+     *
+     * @return array<string>
+     */
+    public static function getSupported(): array
+    {
+        return array_values(static::getConstants());
+    }
+
+    /**
+     * Returns all supported formats, which can be read and write by human(i.e. non-binary).
+     *
+     * @return string[]
+     */
+    public static function getSupportedTextLike(): array
+    {
+        return [
+            self::WKT,
+            self::GEO_JSON,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function getConstants(): array
+    {
+        return (new ReflectionClass(static::class))->getConstants();
+    }
+}

--- a/src/main/Exception/BitrixOrmToolsExceptionInterface.php
+++ b/src/main/Exception/BitrixOrmToolsExceptionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\Exception;
+
+use Throwable;
+
+interface BitrixOrmToolsExceptionInterface extends Throwable
+{
+}

--- a/src/main/Exception/InvalidArgumentException.php
+++ b/src/main/Exception/InvalidArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\Exception;
+
+use InvalidArgumentException as CommonInvalidArgumentException;
+
+class InvalidArgumentException extends CommonInvalidArgumentException implements BitrixOrmToolsExceptionInterface
+{
+}

--- a/src/main/Exception/LogicException.php
+++ b/src/main/Exception/LogicException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\Exception;
+
+use LogicException as CommonLogicException;
+
+class LogicException extends CommonLogicException implements BitrixOrmToolsExceptionInterface
+{
+}

--- a/src/main/Field/GeometryField.php
+++ b/src/main/Field/GeometryField.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\Field;
+
+use Bitrix\Main\ArgumentException;
+use Bitrix\Main\DB\SqlExpression as BxSqlExpression;
+use Bitrix\Main\ORM\Fields\ExpressionField;
+use Bitrix\Main\ORM\Fields\ScalarField;
+use Bitrix\Main\SystemException;
+use WebArch\BitrixOrmTools\Enum\GeometryFormat;
+use WebArch\BitrixOrmTools\Exception\InvalidArgumentException;
+use WebArch\BitrixOrmTools\Exception\LogicException;
+use WebArch\BitrixOrmTools\SqlExpression\MySQL\Enum\GeoJsonOption;
+use WebArch\BitrixOrmTools\SqlExpression\MySQL\Spatial;
+use WebArch\BitrixOrmTools\SqlExpression\MySQL\SqlExpression;
+
+class GeometryField extends ScalarField
+{
+    const PARAM_GEO_JSON_MAX_DEC_DIGITS = 'geo_json_max_dec_digits';
+
+    const PARAM_GEO_JSON_OPTIONS = 'geo_json_options';
+
+    /**
+     * @var string
+     * @see GeometryFormat
+     */
+    private $inputFormat = GeometryFormat::WKT;
+
+    /**
+     * @var string
+     * @see GeometryFormat
+     */
+    private $outputFormat = GeometryFormat::WKT;
+
+    public function __construct($name, $parameters = [])
+    {
+        parent::__construct($name, $parameters);
+        $this->addFetchDataModifier([$this, 'convertValueFromDb']);
+        $this->addSaveDataModifier([$this, 'convertValueToDb']);
+    }
+
+    /**
+     * @param string $name
+     * @param int $maxDecDigits
+     * @param int $options
+     * @param array<string, mixed> $parameters
+     *
+     * @throws ArgumentException
+     * @throws SystemException
+     * @return ExpressionField
+     */
+    public function asGeoJson(
+        string $name,
+        $maxDecDigits = Spatial::MAX_DEC_DIGITS,
+        $options = GeoJsonOption::NO_OPTION,
+        array $parameters = []
+    ): ExpressionField {
+        return new ExpressionField(
+            $name,
+            (string)SqlExpression::create()
+                                 ->spatial()
+                                 ->ST_AsGeoJSON($this, $maxDecDigits, $options),
+            null,
+            $parameters
+        );
+    }
+
+    /**
+     * @param string $name
+     * @param array<string, mixed> $parameters
+     *
+     * @throws ArgumentException
+     * @throws SystemException
+     * @return ExpressionField
+     */
+    public function asWkt(string $name, array $parameters = []): ExpressionField
+    {
+        return new ExpressionField(
+            $name,
+            (string)SqlExpression::create()
+                                 ->spatial()
+                                 ->ST_AsWKT($this),
+            null,
+            $parameters
+        );
+    }
+
+    /**
+     * @param string $name
+     * @param array<string, mixed> $parameters
+     *
+     * @throws ArgumentException
+     * @throws SystemException
+     * @return ExpressionField
+     */
+    public function asWkb(string $name, array $parameters = []): ExpressionField
+    {
+        return new ExpressionField(
+            $name,
+            (string)SqlExpression::create()
+                                 ->spatial()
+                                 ->ST_AsWKB($this),
+            null,
+            $parameters
+        );
+    }
+
+    /**
+     * @param string $name
+     * @param array<string, mixed> $parameters Если $outputFormat === GeometryFormat::GEO_JSON, то в $parameters
+     *     принимаются дополнительные настройки self::PARAM_GEO_JSON_MAX_DEC_DIGITS и self::PARAM_GEO_JSON_OPTIONS (см.
+     *     asGeoJson() )
+     *
+     * @throws ArgumentException
+     * @throws SystemException
+     * @return ExpressionField|GeometryField Возвращает $this, игнорируя аргументы $name и $parameters, если выходной
+     *     формат GeometryFormat::INTERNAL.
+     */
+    public function asOutputFormat(string $name, array $parameters = [])
+    {
+        if (GeometryFormat::WKB === $this->getOutputFormat()) {
+            return $this->asWkb($name, $parameters);
+        }
+        if (GeometryFormat::WKT === $this->getOutputFormat()) {
+            return $this->asWkt($name, $parameters);
+        }
+        if (GeometryFormat::GEO_JSON === $this->getOutputFormat()) {
+            $maxDecDigits = Spatial::MAX_DEC_DIGITS;
+            if (array_key_exists(self::PARAM_GEO_JSON_MAX_DEC_DIGITS, $parameters)) {
+                $maxDecDigits = $parameters[self::PARAM_GEO_JSON_MAX_DEC_DIGITS];
+            }
+            $options = GeoJsonOption::NO_OPTION;
+            if (array_key_exists(self::PARAM_GEO_JSON_OPTIONS, $parameters)) {
+                $options = $parameters[self::PARAM_GEO_JSON_OPTIONS];
+            }
+
+            return $this->asGeoJson($name, $maxDecDigits, $options, $parameters);
+        }
+        if (GeometryFormat::INTERNAL === $this->getOutputFormat()) {
+            return $this;
+        }
+
+        throw new LogicException(
+            sprintf(
+                'Unsupported output format "%s" is set for the field "%s".',
+                $this->getOutputFormat(),
+                $this->getName()
+            )
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function cast($value)
+    {
+        if (!is_string($value) || '' === trim($value)) {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     * @internal Impossible to convert anything, because the value is in a complex format.
+     * @see asWkb
+     * @see asWkt
+     * @see asGeoJson
+     * @see asOutputFormat
+     */
+    public function convertValueFromDb($value)
+    {
+        return $this->cast($value);
+    }
+
+    /**
+     * @inheritDoc
+     * @throws ArgumentException
+     * @return BxSqlExpression|mixed|string
+     */
+    public function convertValueToDb($value)
+    {
+        switch ($this->getInputFormat()) {
+            case GeometryFormat::INTERNAL:
+                return $value;
+            case GeometryFormat::WKB:
+                return SqlExpression::create()->spatial()->ST_GeomFromWKB($value);
+            case GeometryFormat::WKT:
+                return SqlExpression::create()->spatial()->ST_GeomFromText($value);
+            case GeometryFormat::GEO_JSON:
+                return SqlExpression::create()->spatial()->ST_GeomFromGeoJSON($value);
+        }
+        throw new LogicException(
+            sprintf(
+                'Unsupported input format "%s" is set for the field "%s".',
+                $this->getInputFormat(),
+                $this->getName()
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getInputFormat(): string
+    {
+        return $this->inputFormat;
+    }
+
+    /**
+     * @param string $inputFormat
+     *
+     * @return $this
+     */
+    public function configureInputFormat(string $inputFormat)
+    {
+        if (!GeometryFormat::isSupported($inputFormat)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Unsupported input format "%s". Expect one of these values: %s',
+                    $inputFormat,
+                    implode(', ', GeometryFormat::getSupported())
+                )
+            );
+        }
+        $this->inputFormat = $inputFormat;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOutputFormat(): string
+    {
+        return $this->outputFormat;
+    }
+
+    /**
+     * @param string $outputFormat
+     *
+     * @return $this
+     */
+    public function configureOutputFormat(string $outputFormat)
+    {
+        if (!GeometryFormat::isSupported($outputFormat)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Unsupported output format "%s". Expect one of these values: %s',
+                    $outputFormat,
+                    implode(', ', GeometryFormat::getSupported())
+                )
+            );
+        }
+        $this->outputFormat = $outputFormat;
+
+        return $this;
+    }
+}

--- a/src/main/Field/TimeField.php
+++ b/src/main/Field/TimeField.php
@@ -80,14 +80,12 @@ class TimeField extends ScalarField
     public function postInitialize()
     {
         $this->tryGetUserField();
-        if (!is_array($this->userField)) {
+        if (!$this->userFieldHasSettings()) {
             return null;
         }
-
-        if (!array_key_exists('SETTINGS', $this->userField) || !is_array($this->userField['SETTINGS'])) {
-            return null;
-        }
-
+        /**
+         * @phpstan-ignore-next-line Метод userFieldHasSettings() уже проверил наличие ключа 'SETTINGS'.
+         */
         $settings = $this->userField['SETTINGS'];
         if (
             array_key_exists(TimeType::SETTING_REQUIRED, $settings)

--- a/src/main/Field/Traits/UserFieldAwareTrait.php
+++ b/src/main/Field/Traits/UserFieldAwareTrait.php
@@ -67,6 +67,25 @@ trait UserFieldAwareTrait
     }
 
     /**
+     * @return bool
+     */
+    protected function userFieldIsFound(): bool
+    {
+        return is_array($this->userField);
+    }
+
+    /**
+     * @return bool
+     */
+    protected function userFieldHasSettings(): bool
+    {
+        return $this->userFieldIsFound()
+            && is_array($this->userField)
+            && array_key_exists('SETTINGS', $this->userField)
+            && is_array($this->userField['SETTINGS']);
+    }
+
+    /**
      * @return Entity
      */
     abstract public function getEntity();

--- a/src/main/SqlExpression/MySQL/Enum/GeoJsonOption.php
+++ b/src/main/SqlExpression/MySQL/Enum/GeoJsonOption.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\SqlExpression\MySQL\Enum;
+
+/**
+ * Class GeoJsonOption
+ * @package WebArch\BitrixOrmTools\SqlExpression\MySQL\Enum
+ * @link https://dev.mysql.com/doc/refman/5.7/en/spatial-geojson-functions.html#function_st-asgeojson
+ */
+class GeoJsonOption
+{
+    const NO_OPTION = 0;
+
+    const BOUNDING_BOX = 1;
+
+    const SHORT_FORMAT = 2;
+
+    const LONG_FORMAT = 4;
+}

--- a/src/main/SqlExpression/MySQL/Enum/Placeholder.php
+++ b/src/main/SqlExpression/MySQL/Enum/Placeholder.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\SqlExpression\MySQL\Enum;
+
+class Placeholder
+{
+    const STRING = '?s';
+
+    const INTEGER = '?i';
+
+    const FLOAT = '?f';
+
+    const COLUMN = '?#';
+}

--- a/src/main/SqlExpression/MySQL/Spatial.php
+++ b/src/main/SqlExpression/MySQL/Spatial.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\SqlExpression\MySQL;
+
+use Bitrix\Main\ArgumentException;
+use Bitrix\Main\DB\SqlExpression as BxSqlExpression;
+use Bitrix\Main\ORM\Fields\ScalarField;
+use WebArch\BitrixOrmTools\SqlExpression\MySQL\Enum\GeoJsonOption;
+use WebArch\BitrixOrmTools\SqlExpression\MySQL\Traits\PlaceholderTypeTrait;
+
+class Spatial
+{
+    use PlaceholderTypeTrait;
+
+    /**
+     * (2^32) - 1
+     */
+    public const MAX_DEC_DIGITS = 4294967295;
+
+    /**
+     * Converts a value in internal geometry format to its WKT representation and returns the string result.
+     *
+     * @param ScalarField|string $geometry Geometry in MySQL internal geometry format.
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-format-conversion-functions.html#function_st-astext
+     */
+    public function ST_AsText($geometry): BxSqlExpression
+    {
+        [$placeholder, $value] = $this->getPlaceholderAndValue($geometry);
+
+        return new BxSqlExpression('ST_AsText(' . $placeholder . ')', $value);
+    }
+
+    /**
+     * Converts a value in internal geometry format to its WKT representation and returns the string result.
+     *
+     * @param ScalarField|string $geometry Geometry in MySQL internal geometry format.
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-format-conversion-functions.html#function_st-astext
+     */
+    public function ST_AsWKT($geometry): BxSqlExpression
+    {
+        return $this->ST_AsText($geometry);
+    }
+
+    /**
+     * Converts a value in internal geometry format to its WKB representation and returns the binary result.
+     *
+     * @param ScalarField|string $geometry Geometry in MySQL internal geometry format.
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-format-conversion-functions.html#function_st-asbinary
+     */
+    public function ST_AsBinary($geometry): BxSqlExpression
+    {
+        [$placeholder, $value] = $this->getPlaceholderAndValue($geometry);
+
+        return new BxSqlExpression('ST_AsBinary(' . $placeholder . ')', $value);
+    }
+
+    /**
+     * Converts a value in internal geometry format to its WKB representation and returns the binary result.
+     *
+     * @param ScalarField|string $geometry Geometry in MySQL internal geometry format.
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-format-conversion-functions.html#function_st-asbinary
+     */
+    public function ST_AsWKB($geometry): BxSqlExpression
+    {
+        return $this->ST_AsBinary($geometry);
+    }
+
+    /**
+     * Generates a GeoJSON object from the geometry g. The object string has the connection character set and collation.
+     *
+     * @param ScalarField|string $geometry
+     * @param int|ScalarField $maxDecDigits
+     * @param int|ScalarField $options
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/spatial-geojson-functions.html#function_st-asgeojson
+     */
+    public function ST_AsGeoJSON(
+        $geometry,
+        $maxDecDigits = self::MAX_DEC_DIGITS,
+        $options = GeoJsonOption::NO_OPTION
+    ): BxSqlExpression {
+        [$geometryPlaceholder, $geometryValue] = $this->getPlaceholderAndValue($geometry);
+        [$maxDecDigitsPlaceholder, $maxDecDigitsValue] = $this->getPlaceholderAndValue($maxDecDigits);
+        [$optionsPlaceholder, $optionsValue] = $this->getPlaceholderAndValue($options);
+
+        return new BxSqlExpression(
+            sprintf(
+                'ST_AsGeoJSON(%s, %s, %s)',
+                $geometryPlaceholder,
+                $maxDecDigitsPlaceholder,
+                $optionsPlaceholder
+            ),
+            $geometryValue,
+            $maxDecDigitsValue,
+            $optionsValue
+        );
+    }
+
+    /**
+     * Returns a geometry that represents the point set union of the geometry values g1 and g2. If any argument is
+     * NULL, the return value is NULL.
+     *
+     * @param ScalarField|string $geometryA
+     * @param ScalarField|string $geometryB
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/spatial-operator-functions.html#function_st-union
+     */
+    public function ST_Union($geometryA, $geometryB): BxSqlExpression
+    {
+        [$geometryAPlaceholder, $geometryAValue] = $this->getPlaceholderAndValue($geometryA);
+        [$geometryBPlaceholder, $geometryBValue] = $this->getPlaceholderAndValue($geometryB);
+
+        return new BxSqlExpression(
+            sprintf(
+                'ST_Union(%s, %s)',
+                $geometryAPlaceholder,
+                $geometryBPlaceholder
+            ),
+            $geometryAValue,
+            $geometryBValue
+        );
+    }
+
+    /**
+     * Simplifies a geometry using the Douglas-Peucker algorithm and returns a simplified value of the same type.
+     *
+     * ATTENTION: According to Boost.Geometry, geometries might become invalid as a result of the simplification
+     * process, and the process might create self-intersections. To check the validity of the result, pass it to
+     * ST_IsValid().
+     *
+     * @param ScalarField|string $geometry
+     * @param float|ScalarField $maxDistance
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/spatial-convenience-functions.html#function_st-simplify
+     */
+    public function ST_Simplify($geometry, $maxDistance): BxSqlExpression
+    {
+        [$geometryPlaceholder, $geometryValue] = $this->getPlaceholderAndValue($geometry);
+        [$maxDistancePlaceholder, $maxDistanceValue] = $this->getPlaceholderAndValue($maxDistance);
+
+        return new BxSqlExpression(
+            sprintf(
+                'ST_Simplify(%s, %s)',
+                $geometryPlaceholder,
+                $maxDistancePlaceholder
+            ),
+            $geometryValue,
+            $maxDistanceValue
+        );
+    }
+
+    /**
+     * Returns 1 if the argument is syntactically well-formed and is geometrically valid, 0 if the argument is not
+     * syntactically well-formed or is not geometrically valid. If the argument is NULL, the return value is NULL.
+     * Geometry validity is defined by the OGC specification.
+     *
+     * @param ScalarField|string $geometry
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/spatial-convenience-functions.html#function_st-isvalid
+     */
+    public function ST_IsValid($geometry): BxSqlExpression
+    {
+        [$placeholder, $value] = $this->getPlaceholderAndValue($geometry);
+
+        return new BxSqlExpression('ST_IsValid(' . $placeholder . ')', $value);
+    }
+
+    /**
+     * Parses a string $geoJson representing a GeoJSON object and returns a geometry.
+     *
+     * @param ScalarField|string $geoJson
+     * @param null|int|ScalarField $options
+     * @param null|int|ScalarField $srId
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/spatial-geojson-functions.html#function_st-geomfromgeojson
+     *
+     * @noinspection PhpUnusedParameterInspection
+     */
+    public function ST_GeomFromGeoJSON($geoJson, $options = null, $srId = null): BxSqlExpression
+    {
+        [$geoJsonPlaceholder, $geoJsonValue] = $this->getPlaceholderAndValue($geoJson);
+
+        return new BxSqlExpression(
+            sprintf(
+                'ST_GeomFromGeoJSON(%s)',
+                $geoJsonPlaceholder
+            ),
+            $geoJsonValue
+        );
+    }
+
+    /**
+     * Constructs a geometry value of any type using its WKT representation and SRID.
+     *
+     * @param ScalarField|string $wkt
+     * @param null|int|ScalarField $srId
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-wkt-functions.html#function_st-geomfromtext
+     */
+    public function ST_GeomFromText($wkt, $srId = null): BxSqlExpression
+    {
+        [$wktPlaceholder, $wktValue] = $this->getPlaceholderAndValue($wkt);
+
+        if (!is_null($srId)) {
+            [$srIdPlaceholder, $srIdValue] = $this->getPlaceholderAndValue($srId);
+
+            return new BxSqlExpression(
+                sprintf(
+                    'ST_GeomFromText(%s, %s)',
+                    $wktPlaceholder,
+                    $srIdPlaceholder
+                ),
+                $wktValue,
+                $srIdValue
+            );
+        }
+
+        return new BxSqlExpression(
+            sprintf(
+                'ST_GeomFromText(%s)',
+                $wktPlaceholder
+            ),
+            $wktValue
+        );
+    }
+
+    /**
+     * Constructs a geometry value of any type using its WKT representation and SRID.
+     *
+     * @param ScalarField|string $wkt
+     * @param null|int|ScalarField $srId
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-wkt-functions.html#function_st-geomfromtext
+     */
+    public function ST_GeometryFromText($wkt, $srId = null): BxSqlExpression
+    {
+        return $this->ST_GeomFromText($wkt, $srId);
+    }
+
+    /**
+     * Constructs a geometry value of any type using its WKB representation and SRID.
+     *
+     * @param ScalarField|string $wkb
+     * @param null|int|ScalarField $srId
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-wkb-functions.html#function_st-geomfromwkb
+     */
+    public function ST_GeomFromWKB($wkb, $srId = null): BxSqlExpression
+    {
+        [$wkbPlaceholder, $wkbValue] = $this->getPlaceholderAndValue($wkb);
+
+        if (!is_null($srId)) {
+            [$srIdPlaceholder, $srIdValue] = $this->getPlaceholderAndValue($srId);
+
+            return new BxSqlExpression(
+                sprintf(
+                    'ST_GeomFromWKB(%s, %s)',
+                    $wkbPlaceholder,
+                    $srIdPlaceholder
+                ),
+                $wkbValue,
+                $srIdValue
+            );
+        }
+
+        return new BxSqlExpression(
+            sprintf(
+                'ST_GeomFromWKB(%s)',
+                $wkbPlaceholder
+            ),
+            $wkbValue
+        );
+    }
+
+    /**
+     * Constructs a geometry value of any type using its WKB representation and SRID.
+     *
+     * @param ScalarField|string $wkb
+     * @param null|int|ScalarField $srId
+     *
+     * @throws ArgumentException
+     * @return BxSqlExpression
+     *
+     * @link https://dev.mysql.com/doc/refman/5.7/en/gis-wkb-functions.html#function_st-geomfromwkb
+     */
+    public function ST_GeometryFromWKB($wkb, $srId = null): BxSqlExpression
+    {
+        return $this->ST_GeomFromWKB($wkb, $srId);
+    }
+}

--- a/src/main/SqlExpression/MySQL/SqlExpression.php
+++ b/src/main/SqlExpression/MySQL/SqlExpression.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\SqlExpression\MySQL;
+
+/**
+ * Class SqlExpression
+ *
+ * Sql expression helps to build
+ *
+ * @package WebArch\BitrixOrmTools\SqlExpression
+ */
+class SqlExpression
+{
+    /**
+     * @var null|Spatial
+     */
+    private $spatial;
+
+    /**
+     * @return SqlExpression
+     */
+    public static function create()
+    {
+        return new self;
+    }
+
+    /**
+     * @return Spatial
+     */
+    public function spatial(): Spatial
+    {
+        if (is_null($this->spatial)) {
+            $this->spatial = new Spatial();
+        }
+
+        return $this->spatial;
+    }
+}

--- a/src/main/SqlExpression/MySQL/Traits/PlaceholderTypeTrait.php
+++ b/src/main/SqlExpression/MySQL/Traits/PlaceholderTypeTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WebArch\BitrixOrmTools\SqlExpression\MySQL\Traits;
+
+use Bitrix\Main\ORM\Fields\ScalarField;
+use WebArch\BitrixOrmTools\SqlExpression\MySQL\Enum\Placeholder;
+
+trait PlaceholderTypeTrait
+{
+    /**
+     * Automatically guesses suitable placeholder and it's value.
+     *
+     * @param float|int|ScalarField|string $argument
+     *
+     * @return array<mixed> [string $placeholder, mixed $value]
+     * @see \Bitrix\Main\DB\SqlExpression::execPlaceholders
+     */
+    protected function getPlaceholderAndValue($argument): array
+    {
+        if ($argument instanceof ScalarField) {
+            return [Placeholder::COLUMN, $argument->getColumnName()];
+        }
+        if (is_int($argument)) {
+            return [Placeholder::INTEGER, $argument];
+        }
+        if (is_float($argument) || is_numeric($argument)) {
+            return [Placeholder::FLOAT, $argument];
+        }
+
+        return [Placeholder::STRING, $argument];
+    }
+}


### PR DESCRIPTION
Добавлено:
- Новый тип поля GeometryField для работы с типом данных GEOMETRY в базе
данных;
- Хэлпер \WebArch\BitrixOrmTools\SqlExpression\MySQL\SqlExpression и его специфическая часть
  \WebArch\BitrixOrmTools\SqlExpression\MySQL\Spatial для работы со spatial функциями;
- Метод PlaceholderTypeTrait::getPlaceholderAndValue() для автоматического определения типа placeholder и его
  значения по любому из поддерживаемых в \Bitrix\Main\DB\SqlExpression::execPlaceholders() типов данных.

Исправлено:
- Теперь придётся указывать версию библиотеки в composer.json из-за
  взаимной зависимости с webarchitect609/bitrix-user-type , чтобы при
  разработке не падал composer install.